### PR TITLE
Python 3 compatibility.

### DIFF
--- a/proxmoxer/__init__.py
+++ b/proxmoxer/__init__.py
@@ -3,4 +3,4 @@ __copyright__ = '(c) Oleg Butovich 2013'
 __version__ = '0.1.7'
 __licence__ = 'MIT'
 
-from core import *
+from .core import *

--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -42,12 +42,12 @@ class JsonSerializer(object):
     ]
 
     def get_accept_types(self):
-        return self.content_types
+        return ", ".join(self.content_types)
 
     def loads(self, response):
         try:
-            return json.loads(response.content)['data']
-        except ValueError:
+            return json.loads(response.content.decode('utf-8'))['data']
+        except (UnicodeDecodeError, ValueError):
             return response.content
 
 
@@ -60,7 +60,7 @@ class ProxmoxHttpSession(requests.Session):
         #filter out streams
         files = files or {}
         data = data or {}
-        for k, v in data.copy().iteritems():
+        for k, v in data.copy().items():
             if isinstance(v, file):
                 files[k] = v
                 del data[k]

--- a/proxmoxer/core.py
+++ b/proxmoxer/core.py
@@ -2,12 +2,24 @@ __author__ = 'Oleg Butovich'
 __copyright__ = '(c) Oleg Butovich 2013'
 __licence__ = 'MIT'
 
-import httplib
 import os
 import imp
-import urlparse
 import posixpath
 import logging
+
+# Python 3 compatibility:
+try:
+    import httplib
+except ImportError:  # py3
+    from http import client as httplib
+try:
+    import urlparse
+except ImportError:  # py3
+    from urllib import parse as urlparse
+try:
+    basestring
+except NameError:  # py3
+    basestring = (bytes, str)
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +42,7 @@ class ProxmoxResourceBase(object):
         return urlparse.urlunsplit([scheme, netloc, path, query, fragment])
 
 
-class ResourceException(StandardError):
+class ResourceException(Exception):
     pass
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
* Use explicit relative imports (from .core ...).
* Update a few imports for the new Python 3 package names and add the
  basestring hack.
* HTTP headers don't autoconvert lists to a comma-separated string. Do
  it manually.
* JSON functions don't handle bytestrings anymore, decode from UTF-8
  before passing.
* iteritems() is gone, items() returns an iterator. Doesn't cost much
  that Python 2 gets an extra copy.
* StandardError is gone; use Exception.