### PR TITLE
Adapt test_https_connection with requests>=1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ install:
   - pip install . --use-mirrors
   - pip install -r test_requirements.txt --use-mirrors
 script:
-  - nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer.backends.https  -w tests
+  - nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer  -w tests
 after_success:
   - coveralls

--- a/tests/https_tests.py
+++ b/tests/https_tests.py
@@ -13,7 +13,7 @@ def test_https_connection(req_session):
                 'CSRFPreventionToken': 'CSRFPreventionToken'}
     req_session.request.return_value = response
     ProxmoxAPI('proxmox', user='root@pam', password='secret', port=123, verify_ssl=False)
-    call = req_session.return_value.request.call_args[1]
+    call = req_session.return_value.__enter__.return_value.request.call_args[1]
     eq_(call['url'], 'https://proxmox:123/api2/json/access/ticket')
     eq_(call['data'], {'username': 'root@pam', 'password': 'secret'})
     eq_(call['method'], 'post')


### PR DESCRIPTION
Requests>=1.9 start using with...as... syntax in requests.api, mock
method has to adapt it in order to pass unit tests