### PR TITLE
Lock requests version to < 2.9 for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ install:
   - pip install . --use-mirrors
   - pip install -r test_requirements.txt --use-mirrors
 script:
-  - nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer.backends.https  -w tests
+  - nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer  -w tests
 after_success:
   - coveralls

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 mock
 nose
-requests
+requests < 2.9
 coveralls
 paramiko
 openssh_wrapper


### PR DESCRIPTION
In requests >= 2.9, requests.api.request() starts use with..as
syntax for session creating, this will cause failure in https_tests.
test_https_connection, because it's not mocking '__enter__'.
Also because this is an unit requirement, lock version < 2.9 could
be better than assume everyone is using lastest version.