### PR TITLE
Add support to specify an identity file for ssh connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ install:
   - pip install . --use-mirrors
   - pip install -r test_requirements.txt --use-mirrors
 script:
-  - nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer.backends.https  -w tests
+  - nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer  -w tests
 after_success:
   - coveralls

--- a/proxmoxer/backends/openssh.py
+++ b/proxmoxer/backends/openssh.py
@@ -17,6 +17,7 @@ class ProxmoxOpenSSHSession(ProxmoxBaseSSHSession):
     def __init__(self, host,
                  username,
                  configfile=None,
+                 identity_file=None,
                  port=22,
                  timeout=5,
                  forward_ssh_agent=False,
@@ -31,7 +32,8 @@ class ProxmoxOpenSSHSession(ProxmoxBaseSSHSession):
         self.ssh_client = openssh_wrapper.SSHConnection(self.host,
                                                         login=self.username,
                                                         port=self.port,
-                                                        timeout=self.timeout)
+                                                        timeout=self.timeout,
+                                                        identity_file=identity_file)
 
     def _exec(self, cmd):
         if self.sudo:
@@ -44,10 +46,11 @@ class ProxmoxOpenSSHSession(ProxmoxBaseSSHSession):
 
 
 class Backend(BaseBackend):
-    def __init__(self, host, user, configfile=None, port=22, timeout=5, forward_ssh_agent=False, sudo=False):
+    def __init__(self, host, user, configfile=None, identity_file=None, port=22, timeout=5, forward_ssh_agent=False, sudo=False):
         self.session = ProxmoxOpenSSHSession(host, user,
                                              configfile=configfile,
                                              port=port,
                                              timeout=timeout,
                                              forward_ssh_agent=forward_ssh_agent,
-                                             sudo=sudo)
+                                             sudo=sudo,
+                                             identity_file=identity_file)

--- a/tests/https_tests.py
+++ b/tests/https_tests.py
@@ -7,13 +7,13 @@ from nose.tools import eq_, ok_
 from proxmoxer import ProxmoxAPI
 
 
-@patch('requests.sessions.Session')
+@patch('requests.sessions.Session.request')
 def test_https_connection(req_session):
     response = {'ticket': 'ticket',
                 'CSRFPreventionToken': 'CSRFPreventionToken'}
     req_session.request.return_value = response
     ProxmoxAPI('proxmox', user='root@pam', password='secret', port=123, verify_ssl=False)
-    call = req_session.return_value.request.call_args[1]
+    call = req_session.call_args[1]
     eq_(call['url'], 'https://proxmox:123/api2/json/access/ticket')
     eq_(call['data'], {'username': 'root@pam', 'password': 'secret'})
     eq_(call['method'], 'post')


### PR DESCRIPTION
- Supports identity file to be specified while created openssh session
- Fixed unit tests to be compatible with newer requests version