### PR TITLE
Update https.py

### DIFF
--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -8,8 +8,7 @@ import sys
 
 try:
     import requests
-    urllib3 = requests.packages.urllib3
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    import urllib3
     from requests.auth import AuthBase
     from requests.cookies import cookiejar_from_dict
 except ImportError:


### PR DESCRIPTION
Changed import for compatibility with python 2.7

Traceback (most recent call last):
  File "./container_host_mapping.py", line 57, in <module>
    MAPPER = ContainerToHostMapper()
  File "./container_host_mapping.py", line 35, in **init**
    password=self.password, verify_ssl=False)
  File "/usr/local/lib/python2.7/dist-packages/proxmoxer/core.py", line 107, in **init**
    self._backend = imp.load_module(backend, _found_module).Backend(host, *_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/proxmoxer/backends/https.py", line 11, in <module>
    urllib3 = requests.packages.urllib3
AttributeError: 'module' object has no attribute 'packages'
