### PR TITLE
proxmoxer/backends/ssh_paramiko: improve file uplod (it was very slow)

### DIFF
--- a/proxmoxer/backends/ssh_paramiko.py
+++ b/proxmoxer/backends/ssh_paramiko.py
@@ -58,9 +58,8 @@ class ProxmoxParamikoSession(ProxmoxBaseSSHSession):
 
     def upload_file_obj(self, file_obj, remote_path):
         sftp = self.ssh_client.open_sftp()
-        remote_file = sftp.open(remote_path, 'wb')
-        remote_file.write(file_obj.read())
-        remote_file.close()
+        sftp.putfo(file_obj, remote_path)
+        sftp.close()
 
 
 class Backend(BaseBackend):


### PR DESCRIPTION
Upload file using paramiko backend is very very slow right now. Using putfo methed of SFTPClient fix this issue.
