### PR TITLE
Adding sudo to execute CLI with paramiko ssh backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env/
+*.egg-info/
+*.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
   - 2.7
   - 3.4
 install:
-  - pip install . --use-mirrors
-  - pip install -r test_requirements.txt --use-mirrors
+  - pip install .
+  - pip install -r test_requirements.txt
 script:
   - nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer  -w tests
 after_success:

--- a/proxmoxer/backends/ssh_paramiko.py
+++ b/proxmoxer/backends/ssh_paramiko.py
@@ -20,13 +20,15 @@ class ProxmoxParamikoSession(ProxmoxBaseSSHSession):
                  password=None,
                  private_key_file=None,
                  port=22,
-                 timeout=5):
+                 timeout=5,
+                 sudo=False):
         self.host = host
         self.username = username
         self.password = password
         self.private_key_file = private_key_file
         self.port = port
         self.timeout = timeout
+        self.sudo = sudo
         self.ssh_client = self._connect()
 
     def _connect(self):
@@ -50,6 +52,8 @@ class ProxmoxParamikoSession(ProxmoxBaseSSHSession):
         return ssh_client
 
     def _exec(self, cmd):
+        if self.sudo:
+            cmd = 'sudo ' + cmd
         session = self.ssh_client.get_transport().open_session()
         session.exec_command(cmd)
         stdout = ''.join(session.makefile('rb', -1))
@@ -64,11 +68,12 @@ class ProxmoxParamikoSession(ProxmoxBaseSSHSession):
 
 
 class Backend(BaseBackend):
-    def __init__(self, host, user, password=None, private_key_file=None, port=22, timeout=5):
+    def __init__(self, host, user, password=None, private_key_file=None, port=22, timeout=5, sudo=False):
         self.session = ProxmoxParamikoSession(host, user,
                                               password=password,
                                               private_key_file=private_key_file,
                                               port=port,
-                                              timeout=timeout)
+                                              timeout=timeout,
+                                              sudo=sudo)
 
 

--- a/tests/base/base_ssh_suite.py
+++ b/tests/base/base_ssh_suite.py
@@ -12,16 +12,25 @@ except ImportError:
 from nose.tools import eq_, ok_
 
 
-class BaseSSHSuite():
+class BaseSSHSuite(object):
     proxmox = None
     client = None
     session = None
 
+    def __init__(self, sudo=False):
+        self.sudo = sudo
+
     def _split_cmd(self, cmd):
         splitted = cmd.split()
-        eq_(splitted[0], 'pvesh')
+        if not self.sudo:
+            eq_(splitted[0], 'pvesh')
+        else:
+            eq_(splitted[0], 'sudo')
+            eq_(splitted[1], 'pvesh')
+            splitted.pop(0)
         options_set = set((' '.join((k, v)) for k, v in
-                           zip(islice(splitted, 3, None, 2), islice(splitted, 4, None, 2))))
+                           zip(islice(splitted, 3, None, 2),
+                               islice(splitted, 4, None, 2))))
         return ' '.join(splitted[1:3]), options_set
 
     def _get_called_cmd(self):
@@ -53,7 +62,7 @@ class BaseSSHSuite():
                }
             ]""")
         result = self.proxmox.nodes('proxmox').storage('local').get()
-        eq_(self._get_called_cmd(), 'pvesh get /nodes/proxmox/storage/local')
+        eq_(self._get_called_cmd(), self._called_cmd('pvesh get /nodes/proxmox/storage/local'))
         eq_(result[0]['subdir'], 'status')
         eq_(result[1]['subdir'], 'content')
         eq_(result[2]['subdir'], 'upload')
@@ -62,11 +71,11 @@ class BaseSSHSuite():
 
     def test_delete(self):
         self.proxmox.nodes('proxmox').openvz(100).delete()
-        eq_(self._get_called_cmd(), 'pvesh delete /nodes/proxmox/openvz/100')
+        eq_(self._get_called_cmd(), self._called_cmd('pvesh delete /nodes/proxmox/openvz/100'))
         self.proxmox.nodes('proxmox').openvz('101').delete()
-        eq_(self._get_called_cmd(), 'pvesh delete /nodes/proxmox/openvz/101')
+        eq_(self._get_called_cmd(), self._called_cmd('pvesh delete /nodes/proxmox/openvz/101'))
         self.proxmox.nodes('proxmox').openvz.delete('102')
-        eq_(self._get_called_cmd(), 'pvesh delete /nodes/proxmox/openvz/102')
+        eq_(self._get_called_cmd(), self._called_cmd('pvesh delete /nodes/proxmox/openvz/102'))
 
     def test_post(self):
         node = self.proxmox.nodes('proxmox')
@@ -135,3 +144,9 @@ class BaseSSHSuite():
         ok_('-ip_address 10.0.100.200' in options)
         ok_('-onboot False' in options)
         ok_('-cpus 2' in options)
+
+    def _called_cmd(self, cmd):
+        called_cmd = cmd
+        if self.sudo:
+            called_cmd = 'sudo ' + cmd
+        return called_cmd

--- a/tests/paramiko_tests.py
+++ b/tests/paramiko_tests.py
@@ -42,3 +42,24 @@ class TestParamikoSuite(BaseSSHSuite):
     def _set_stderr(self, stderr):
         self.session.makefile_stderr.return_value = [stderr]
 
+
+class TestParamikoSuiteWithSudo(BaseSSHSuite):
+
+    # noinspection PyMethodOverriding
+    @patch('paramiko.SSHClient')
+    def setUp(self, _):
+        super(TestParamikoSuiteWithSudo, self).__init__(sudo=True)
+        self.proxmox = ProxmoxAPI('proxmox', user='root', backend='ssh_paramiko', port=123, sudo=True)
+        self.client = self.proxmox._store['session'].ssh_client
+        self.session = self.client.get_transport().open_session()
+        self._set_stderr('200 OK')
+        self._set_stdout('')
+
+    def _get_called_cmd(self):
+        return self.session.exec_command.call_args[0][0]
+
+    def _set_stdout(self, stdout):
+        self.session.makefile.return_value = [stdout]
+
+    def _set_stderr(self, stderr):
+        self.session.makefile_stderr.return_value = [stderr]


### PR DESCRIPTION
Adding sudo to execute CLI with paramiko ssh backend

- added tests for sudo in paramiko
- added .gitignore file
- remove `--use-mirrors` in travis.yml as it has been removed via
https://pip.pypa.io/en/stable/news/ and 7.0.0 (2015-05-21) section

Running tests yields:
```
(.env)[paramiko-sudo]->$ nosetests
..................
----------------------------------------------------------------------
Ran 18 tests in 0.178s

OK
```