### PR TITLE
Fix issue where when using unsigned SSL cert, requests would fail

### DIFF
--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -90,6 +90,9 @@ class ProxmoxHttpSession(requests.Session):
                 timeout=None, allow_redirects=True, proxies=None, hooks=None, stream=None, verify=None, cert=None,
                 serializer=None):
 
+        # At this point 'verify'=None, so set it to what we want.
+        verify = self.verify
+
         #filter out streams
         files = files or {}
         data = data or {}


### PR DESCRIPTION
 because verify did not get assigned the way we wanted.

I am unsure if my fix is done in the right place, so please let me know if I am wrong.