### PR TITLE
paramiko python3: stdout and stderr must be a str not bytes

### DIFF
--- a/proxmoxer/backends/ssh_paramiko.py
+++ b/proxmoxer/backends/ssh_paramiko.py
@@ -56,8 +56,8 @@ class ProxmoxParamikoSession(ProxmoxBaseSSHSession):
             cmd = 'sudo ' + cmd
         session = self.ssh_client.get_transport().open_session()
         session.exec_command(cmd)
-        stdout = ''.join(session.makefile('rb', -1))
-        stderr = ''.join(session.makefile_stderr('rb', -1))
+        stdout = session.makefile('rb', -1).read().decode()
+        stderr = session.makefile_stderr('rb', -1).read().decode()
         return stdout, stderr
 
     def upload_file_obj(self, file_obj, remote_path):

--- a/tests/base/base_ssh_suite.py
+++ b/tests/base/base_ssh_suite.py
@@ -72,12 +72,15 @@ class BaseSSHSuite(object):
     def test_delete(self):
         self.proxmox.nodes('proxmox').openvz(100).delete()
         eq_(self._get_called_cmd(), self._called_cmd('pvesh delete /nodes/proxmox/openvz/100'))
+        self._set_stderr("200 OK")
         self.proxmox.nodes('proxmox').openvz('101').delete()
         eq_(self._get_called_cmd(), self._called_cmd('pvesh delete /nodes/proxmox/openvz/101'))
+        self._set_stderr("200 OK")
         self.proxmox.nodes('proxmox').openvz.delete('102')
         eq_(self._get_called_cmd(), self._called_cmd('pvesh delete /nodes/proxmox/openvz/102'))
 
     def test_post(self):
+        self._set_stderr("200 OK")
         node = self.proxmox.nodes('proxmox')
         node.openvz.create(vmid=800,
                            ostemplate='local:vztmpl/debian-6-turnkey-core_12.0-1_i386.tar.gz',
@@ -102,6 +105,7 @@ class BaseSSHSuite(object):
         ok_('-swap 512' in options)
         ok_('-vmid 800' in options)
 
+        self._set_stderr("200 OK")
         node = self.proxmox.nodes('proxmox1')
         node.openvz.post(vmid=900,
                          ostemplate='local:vztmpl/debian-7-turnkey-core_12.0-1_i386.tar.gz',
@@ -127,6 +131,7 @@ class BaseSSHSuite(object):
         ok_('-vmid 900' in options)
 
     def test_put(self):
+        self._set_stderr("200 OK")
         node = self.proxmox.nodes('proxmox')
         node.openvz(101).config.set(cpus=4, memory=1024, ip_address='10.0.100.100', onboot=True)
         cmd, options = self._split_cmd(self._get_called_cmd())
@@ -136,6 +141,7 @@ class BaseSSHSuite(object):
         ok_('-onboot True' in options)
         ok_('-cpus 4' in options)
 
+        self._set_stderr("200 OK")
         node = self.proxmox.nodes('proxmox1')
         node.openvz('102').config.put(cpus=2, memory=512, ip_address='10.0.100.200', onboot=False)
         cmd, options = self._split_cmd(self._get_called_cmd())

--- a/tests/paramiko_tests.py
+++ b/tests/paramiko_tests.py
@@ -2,6 +2,7 @@ __author__ = 'Oleg Butovich'
 __copyright__ = '(c) Oleg Butovich 2013-2017'
 __licence__ = 'MIT'
 
+import io
 from mock import patch
 from nose.tools import eq_
 from proxmoxer import ProxmoxAPI
@@ -37,10 +38,10 @@ class TestParamikoSuite(BaseSSHSuite):
         return self.session.exec_command.call_args[0][0]
 
     def _set_stdout(self, stdout):
-        self.session.makefile.return_value = [stdout]
+        self.session.makefile.return_value = io.BytesIO(stdout.encode('utf-8'))
 
     def _set_stderr(self, stderr):
-        self.session.makefile_stderr.return_value = [stderr]
+        self.session.makefile_stderr.return_value = io.BytesIO(stderr.encode('utf-8'))
 
 
 class TestParamikoSuiteWithSudo(BaseSSHSuite):
@@ -59,7 +60,7 @@ class TestParamikoSuiteWithSudo(BaseSSHSuite):
         return self.session.exec_command.call_args[0][0]
 
     def _set_stdout(self, stdout):
-        self.session.makefile.return_value = [stdout]
+        self.session.makefile.return_value = io.BytesIO(stdout.encode('utf-8'))
 
     def _set_stderr(self, stderr):
-        self.session.makefile_stderr.return_value = [stderr]
+        self.session.makefile_stderr.return_value = io.BytesIO(stderr.encode('utf-8'))


### PR DESCRIPTION
Paramiko doesn't work with Python3. This PR fixes the bug. Without this patch I have the following error:

```
In [1]: from proxmoxer import ProxmoxAPI
In [2]: proxmox = ProxmoxAPI('fproxmox_server', user='root', backend='ssh_paramiko')
In [3]: proxmox.cluster.resources.get(type='vm')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-69749f99afc9> in <module>()
----> 1 proxmox.cluster.resources.get(type='vm')

~/.venv/cmdb/lib/python3.5/site-packages/proxmoxer/core.py in get(self, *args, **params)
     82 
     83     def get(self, *args, **params):
---> 84         return self(args)._request("GET", params=params)
     85 
     86     def post(self, *args, **data):

~/.venv/cmdb/lib/python3.5/site-packages/proxmoxer/core.py in _request(self, method, data, params)
     72         else:
     73             logger.info('%s %s', method, url)
---> 74         resp = self._store["session"].request(method, url, data=data or None, params=params)
     75         logger.debug('Status code: %s, output: %s', resp.status_code, resp.content)
     76 

~/.venv/cmdb/lib/python3.5/site-packages/proxmoxer/backends/base_ssh.py in request(self, method, url, data, params, headers)
     44         full_cmd = 'pvesh {0}'.format(' '.join(filter(None, (cmd, url, translated_data))))
     45 
---> 46         stdout, stderr = self._exec(full_cmd)
     47         match = lambda s: re.match('\d\d\d [a-zA-Z]', s)
     48         # sometimes contains extra text like 'trying to acquire lock...OK'

~/.venv/cmdb/lib/python3.5/site-packages/proxmoxer/backends/ssh_paramiko.py in _exec(self, cmd)
     57         session = self.ssh_client.get_transport().open_session()
     58         session.exec_command(cmd)
---> 59         stdout = ''.join(session.makefile('rb', -1))
     60         stderr = ''.join(session.makefile_stderr('rb', -1))
     61         return stdout, stderr

TypeError: sequence item 0: expected str instance, bytes found
```

This PR also fixes paramiko unit tests. TestParamiko return io.BytesIO instead of a list for stdout and
stderr to look like paramiko.channel.channelfile object.