### PR TITLE
proxmoxer/backends/base_ssh.py: add stderr on the Response content

### DIFF
--- a/proxmoxer/backends/base_ssh.py
+++ b/proxmoxer/backends/base_ssh.py
@@ -49,7 +49,10 @@ class ProxmoxBaseSSHSession(object):
         status_code = next(
             (int(s.split()[0]) for s in stderr.splitlines() if match(s)),
             500)
-        return Response(stdout, status_code)
+        if stdout:
+            return Response(stdout, status_code)
+        else:
+            return Response(stderr, status_code)
 
     def upload_file_obj(self, file_obj, remote_path):
         raise NotImplementedError()


### PR DESCRIPTION
It's great to show response content when we have a 500 but it's better to show error when we have one.