### PR TITLE
Fixing output parsing for pvesh 5.3

### DIFF
--- a/proxmoxer/backends/base_ssh.py
+++ b/proxmoxer/backends/base_ssh.py
@@ -41,14 +41,18 @@ class ProxmoxBaseSSHSession(object):
             data['tmpfilename'] = tmp_filename
 
         translated_data = ' '.join(["-{0} {1}".format(k, v) for k, v in chain(data.items(), params.items())])
-        full_cmd = 'pvesh {0}'.format(' '.join(filter(None, (cmd, url, translated_data))))
+        full_cmd = 'pvesh {0} --output-format json'.format(' '.join(filter(None, (cmd, url, translated_data))))
 
         stdout, stderr = self._exec(full_cmd)
         match = lambda s: re.match('\d\d\d [a-zA-Z]', s)
         # sometimes contains extra text like 'trying to acquire lock...OK'
-        status_code = next(
-            (int(s.split()[0]) for s in stderr.splitlines() if match(s)),
-            500)
+        if stderr:
+            status_code = next(
+                (int(s.split()[0]) for s in stderr.splitlines() if match(s)),
+                500)
+        else:
+            status_code = 200
+
         if stdout:
             return Response(stdout, status_code)
         else:

--- a/tests/base/base_ssh_suite.py
+++ b/tests/base/base_ssh_suite.py
@@ -62,7 +62,7 @@ class BaseSSHSuite(object):
                }
             ]""")
         result = self.proxmox.nodes('proxmox').storage('local').get()
-        eq_(self._get_called_cmd(), self._called_cmd('pvesh get /nodes/proxmox/storage/local'))
+        eq_(self._get_called_cmd(), self._called_cmd('pvesh get /nodes/proxmox/storage/local --output-format json'))
         eq_(result[0]['subdir'], 'status')
         eq_(result[1]['subdir'], 'content')
         eq_(result[2]['subdir'], 'upload')
@@ -71,16 +71,16 @@ class BaseSSHSuite(object):
 
     def test_delete(self):
         self.proxmox.nodes('proxmox').openvz(100).delete()
-        eq_(self._get_called_cmd(), self._called_cmd('pvesh delete /nodes/proxmox/openvz/100'))
-        self._set_stderr("200 OK")
+        eq_(self._get_called_cmd(), self._called_cmd('pvesh delete /nodes/proxmox/openvz/100 --output-format json'))
+        self._set_stderr("")
         self.proxmox.nodes('proxmox').openvz('101').delete()
-        eq_(self._get_called_cmd(), self._called_cmd('pvesh delete /nodes/proxmox/openvz/101'))
-        self._set_stderr("200 OK")
+        eq_(self._get_called_cmd(), self._called_cmd('pvesh delete /nodes/proxmox/openvz/101 --output-format json'))
+        self._set_stderr("")
         self.proxmox.nodes('proxmox').openvz.delete('102')
-        eq_(self._get_called_cmd(), self._called_cmd('pvesh delete /nodes/proxmox/openvz/102'))
+        eq_(self._get_called_cmd(), self._called_cmd('pvesh delete /nodes/proxmox/openvz/102 --output-format json'))
 
     def test_post(self):
-        self._set_stderr("200 OK")
+        self._set_stderr("")
         node = self.proxmox.nodes('proxmox')
         node.openvz.create(vmid=800,
                            ostemplate='local:vztmpl/debian-6-turnkey-core_12.0-1_i386.tar.gz',
@@ -105,7 +105,7 @@ class BaseSSHSuite(object):
         ok_('-swap 512' in options)
         ok_('-vmid 800' in options)
 
-        self._set_stderr("200 OK")
+        self._set_stderr("")
         node = self.proxmox.nodes('proxmox1')
         node.openvz.post(vmid=900,
                          ostemplate='local:vztmpl/debian-7-turnkey-core_12.0-1_i386.tar.gz',
@@ -131,7 +131,7 @@ class BaseSSHSuite(object):
         ok_('-vmid 900' in options)
 
     def test_put(self):
-        self._set_stderr("200 OK")
+        self._set_stderr("")
         node = self.proxmox.nodes('proxmox')
         node.openvz(101).config.set(cpus=4, memory=1024, ip_address='10.0.100.100', onboot=True)
         cmd, options = self._split_cmd(self._get_called_cmd())
@@ -141,7 +141,7 @@ class BaseSSHSuite(object):
         ok_('-onboot True' in options)
         ok_('-cpus 4' in options)
 
-        self._set_stderr("200 OK")
+        self._set_stderr("")
         node = self.proxmox.nodes('proxmox1')
         node.openvz('102').config.put(cpus=2, memory=512, ip_address='10.0.100.200', onboot=False)
         cmd, options = self._split_cmd(self._get_called_cmd())
@@ -156,8 +156,9 @@ class BaseSSHSuite(object):
         self._set_stderr("500 whoops")
         self.proxmox.nodes('proxmox').get()
 
-    def test_no_error_with_extra_output(self):
-        self._set_stderr("Extra output\n200 OK")
+    @raises(ResourceException)
+    def test_extra_output_error(self):
+        self._set_stderr("Extra output\n")
         self.proxmox.nodes('proxmox').get()
 
     @raises(ResourceException)

--- a/tests/openssh_tests.py
+++ b/tests/openssh_tests.py
@@ -16,7 +16,7 @@ class TestOpenSSHSuite(BaseSSHSuite):
     def setUp(self, _):
         self.proxmox = ProxmoxAPI('proxmox', user='root', backend='openssh', port=123)
         self.client = self.proxmox._store['session'].ssh_client
-        self._set_stderr('200 OK')
+        self._set_stderr('')
         self._set_stdout('')
 
     def _get_called_cmd(self):

--- a/tests/paramiko_tests.py
+++ b/tests/paramiko_tests.py
@@ -31,7 +31,7 @@ class TestParamikoSuite(BaseSSHSuite):
         self.proxmox = ProxmoxAPI('proxmox', user='root', backend='ssh_paramiko', port=123)
         self.client = self.proxmox._store['session'].ssh_client
         self.session = self.client.get_transport().open_session()
-        self._set_stderr('200 OK')
+        self._set_stderr('')
         self._set_stdout('')
 
     def _get_called_cmd(self):
@@ -53,7 +53,7 @@ class TestParamikoSuiteWithSudo(BaseSSHSuite):
         self.proxmox = ProxmoxAPI('proxmox', user='root', backend='ssh_paramiko', port=123, sudo=True)
         self.client = self.proxmox._store['session'].ssh_client
         self.session = self.client.get_transport().open_session()
-        self._set_stderr('200 OK')
+        self._set_stderr('')
         self._set_stdout('')
 
     def _get_called_cmd(self):


### PR DESCRIPTION
Fixes https://github.com/swayf/proxmoxer/issues/67

It looks like #59 and #55 are stucked so I created quick fix.

**Important: it won't work with previous versions of pvesh** - they dont have ```--format-output``` option.