### PR TITLE
Add support for resources with dashes in name

### DIFF
--- a/proxmoxer/core.py
+++ b/proxmoxer/core.py
@@ -29,6 +29,9 @@ class ProxmoxResourceBase(object):
         if item.startswith("_"):
             raise AttributeError(item)
 
+        # turn underscore into dash to support resource with dash in name
+        item = item.replace('_', '-')
+
         kwargs = self._store.copy()
         kwargs['base_url'] = self.url_join(self._store["base_url"], item)
 


### PR DESCRIPTION
Proxmox API includes a few resources with dashes (-) in their name (like /api2/json/nodes/{node}/qemu/{vmid}/agent/get-host-name).
However the dash character (-) is not authorized in Python object attributes.

This PR adds support for this kind of resource's name by replacing dashes by underscores.

Exemple code :
```python
client.nodes('my_node').qemu(12).agent.get_host_name.get()
```
will call the API URL : `/api2/json/nodes/my_node/qemu/12/agent/get-host-name`