### PR TITLE
Advanced error message with error code >=400

### DIFF
--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -38,9 +38,10 @@ class AuthenticationError(Exception):
 
 
 class ProxmoxHTTPAuth(AuthBase):
-    def __init__(self, base_url, username, password, verify_ssl=False):
+    def __init__(self, base_url, username, password, verify_ssl=False, timeout=5):
         response_data = requests.post(base_url + "/access/ticket",
                                       verify=verify_ssl,
+                                      timeout=timeout,
                                       data={"username": username, "password": password}).json()["data"]
         if response_data is None:
             raise AuthenticationError("Couldn't authenticate user: {0} to {1}".format(username, base_url + "/access/ticket"))
@@ -122,7 +123,7 @@ class Backend(object):
         if auth_token is not None:
             self.auth = ProxmoxHTTPTokenAuth(auth_token, csrf_token)
         else:
-            self.auth = ProxmoxHTTPAuth(self.base_url, user, password, verify_ssl)
+            self.auth = ProxmoxHTTPAuth(self.base_url, user, password, verify_ssl, timeout)
         self.verify_ssl = verify_ssl
         self.mode = mode
         self.timeout = timeout

--- a/proxmoxer/core.py
+++ b/proxmoxer/core.py
@@ -85,11 +85,18 @@ class ProxmoxResource(ProxmoxResourceBase):
         logger.debug('Status code: %s, output: %s', resp.status_code, resp.content)
 
         if resp.status_code >= 400:
-            raise ResourceException("{0} {1}: {2}".format(
-                resp.status_code,
-                httplib.responses.get(resp.status_code,
-                                      ANYEVENT_HTTP_STATUS_CODES.get(resp.status_code)),
-                resp.content))
+            if hasattr(resp, 'reason'):
+                raise ResourceException("{0} {1}: {2} - {3}".format(
+                    resp.status_code,
+                    httplib.responses.get(resp.status_code,
+                                          ANYEVENT_HTTP_STATUS_CODES.get(resp.status_code)),
+                    resp.reason, resp.content))
+            else:
+                raise ResourceException("{0} {1}: {2}".format(
+                    resp.status_code,
+                    httplib.responses.get(resp.status_code,
+                                          ANYEVENT_HTTP_STATUS_CODES.get(resp.status_code)),
+                    resp.content))
         elif 200 <= resp.status_code <= 299:
             return self._store["serializer"].loads(resp)
 


### PR DESCRIPTION
When creating a container with the wrong ssh key, we get an error message that does not clarify the essence of the error.

**SIMULAR PROBLEM:**

Issue https://github.com/ansible/ansible/issues/25113
Pull request https://github.com/swayf/proxmoxer/pull/34

**STEPS TO REPRODUCE**

Playbook:

``` yaml
---
 - hosts: proxmox_api_host
   gather_facts: no
   tasks:
     - name: "Create container with ID 150"
       proxmox:
         vmid: 150
         node: "proxmox-node"
         api_host: "proxmox-node"
         api_user: "root@pam"
         api_password: "PASSWORD"
         hostname: "test-150"
         password: "123456"
         ostemplate: "local:vztmpl/ubuntu-18.04-standard_18.04.1-1_amd64.tar.gz"
         cores: "1"
         memory: "512"
         disk: "2"
         netif: "{"net0":"name=eth0,gw=192.168.1.1,ip=192.168.1.150/24,bridge=vmbr0"}"
         nameserver: "192.168.1.1"
         storage: "local-lvm"
         pubkey: "~/.ssh/id_rsa.pub"
```
		 
		 
**EXPECTED RESULTS**

LXC container created

**ACTUAL RESULTS**		 
		 
		 
```
<192.168.1.231> (1, '\n{"msg": "creation of lxc VM 150 failed with exception: 500 Internal Server Error: {\\"data\\":null}", 
"failed": true, "exception": "WARNING: The below traceback may *not* be related to the actual failure.\\n  
File \\"/tmp/ansible_proxmox_payload_ke3ZcF/__main__.py\\", line 531, in main\\n    unprivileged=int(module.params[\'unprivileged\']))\\n 
 File \\"/tmp/ansible_proxmox_payload_ke3ZcF/__main__.py\\", line 357, in create_instance\\n    taskid = getattr(proxmox_node, VZ_TYPE).create(vmid=vmid, storage=storage, memory=memory, swap=swap, **kwargs)\\n  
 File \\"/usr/local/lib/python2.7/dist-packages/proxmoxer/core.py\\", line 100, in create\\n    return self.post(*args, **data)\\n  
 File \\"/usr/local/lib/python2.7/dist-packages/proxmoxer/core.py\\", line 91, in post\\n    return self(args)._request(\\"POST\\", data=data)\\n  
 File \\"/usr/local/lib/python2.7/dist-packages/proxmoxer/core.py\\", line 83, in _request\\n    resp.reason, resp.content))\\n", "invocation": {"module_args": {"force": false, "cpus": 1, "ostemplate": "local:vztmpl/ubuntu-18.04-standard_18.04.1-1_amd64.tar.gz", "unprivileged": false, "disk": "2", "searchdomain": null, "api_user": "root@pam", "hostname": "test-150", "storage": "local-lvm", "state": "present", "swap": 0, "memory": 512, "pubkey": "~/.ssh/id_rsa.pub", "node": "proxmox-node", "cpuunits": 1000, "api_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "ip_address": null, "pool": null, "api_host": "proxmox-node", "netif": {"net0": "name=eth0,gw=192.168.1.1,ip=192.168.1.150/24,bridge=vmbr0"}, "vmid": "150", "timeout": 30, "mounts": null, "cores": 1, "nameserver": "192.168.1.1", "validate_certs": false, "onboot": false}}, 
 "warnings": ["The value 150 (type int) in a string field was converted to u\'150\' (type string). 
 If this does not look like what you expect, quote the entire value to ensure it does not change.", 
 "The value 2 (type int) in a string field was converted to u\'2\' (type string). 
 If this does not look like what you expect, quote the entire value to ensure it does not change."]}\n', '
 OpenSSH_7.4p1 Debian-10+deb9u6, OpenSSL 1.0.2s  28 May 2019\r\ndebug1: 
 Reading configuration data /etc/ssh/ssh_config\r\ndebug1: /etc/ssh/ssh_config line 19: Applying options for *\r\ndebug1: auto-mux: 
 Trying existing master\r\ndebug2: fd 3 setting O_NONBLOCK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug3: mux_client_forwards: request forwardings: 0 local, 0 remote\r\ndebug3: mux_client_request_session: entering\r\ndebug3: mux_client_request_alive: entering\r\ndebug3: mux_client_request_alive: done pid = 87379\r\ndebug3: mux_client_request_session: session request sent\r\ndebug1: mux_client_request_session: master session id: 2\r\ndebug3: mux_client_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 1\r\n')
<192.168.1.231> Failed to connect to the host via ssh: OpenSSH_7.4p1 Debian-10+deb9u6, OpenSSL 1.0.2s  28 May 2019
debug1: Reading configuration data /etc/ssh/ssh_config
debug1: /etc/ssh/ssh_config line 19: Applying options for *
debug1: auto-mux: Trying existing master
debug2: fd 3 setting O_NONBLOCK
debug2: mux_client_hello_exchange: master version 4
debug3: mux_client_forwards: request forwardings: 0 local, 0 remote
debug3: mux_client_request_session: entering
debug3: mux_client_request_alive: entering
debug3: mux_client_request_alive: done pid = 87379
debug3: mux_client_request_session: session request sent
debug1: mux_client_request_session: master session id: 2
debug3: mux_client_read_packet: read header failed: Broken pipe
debug2: Received exit status from master 1
The full traceback is:
WARNING: The below traceback may *not* be related to the actual failure.
  File "/tmp/ansible_proxmox_payload_ke3ZcF/__main__.py", line 531, in main
    unprivileged=int(module.params['unprivileged']))
  File "/tmp/ansible_proxmox_payload_ke3ZcF/__main__.py", line 357, in create_instance
    taskid = getattr(proxmox_node, VZ_TYPE).create(vmid=vmid, storage=storage, memory=memory, swap=swap, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/proxmoxer/core.py", line 100, in create
    return self.post(*args, **data)
  File "/usr/local/lib/python2.7/dist-packages/proxmoxer/core.py", line 91, in post
    return self(args)._request("POST", data=data)
  File "/usr/local/lib/python2.7/dist-packages/proxmoxer/core.py", line 83, in _request
    resp.reason, resp.content))

 [WARNING]: The value 150 (type int) in a string field was converted to u'150' (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.

 [WARNING]: The value 2 (type int) in a string field was converted to u'2' (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
```

``` yaml
fatal: [192.168.1.231]: FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    }, 
    "changed": false, 
    "invocation": {
        "module_args": {
            "api_host": "proxmox-node", 
            "api_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "api_user": "root@pam", 
            "cores": 1, 
            "cpus": 1, 
            "cpuunits": 1000, 
            "disk": "2", 
            "force": false, 
            "hostname": "test-150", 
            "ip_address": null, 
            "memory": 512, 
            "mounts": null, 
            "nameserver": "192.168.1.1", 
            "netif": {
                "net0": "name=eth0,gw=192.168.1.1,ip=192.168.1.150/24,bridge=vmbr0"
            }, 
            "node": "proxmox-node", 
            "onboot": false, 
            "ostemplate": "local:vztmpl/ubuntu-18.04-standard_18.04.1-1_amd64.tar.gz", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "pool": null, 
            "pubkey": "~/.ssh/id_rsa.pub", 
            "searchdomain": null, 
            "state": "present", 
            "storage": "local-lvm", 
            "swap": 0, 
            "timeout": 30, 
            "unprivileged": false, 
            "validate_certs": false, 
            "vmid": "150"
        }
    }, 
    "msg": "creation of lxc VM 150 failed with exception: 500 Internal Server Error: {\"data\":null}"

```	

The variable **resp** from the https://github.com/swayf/proxmoxer/blob/master/proxmoxer/core.py#L78 file has the following contents at the time of the error:
	
	
``` yaml
{'_content': '{"data":null}',
 '_content_consumed': True,
 'connection': <requests.adapters.HTTPAdapter object at 0x7fe214c34d50>,
 'cookies': <RequestsCookieJar[]>,
 'elapsed': datetime.timedelta(0, 0, 73327),
 'encoding': 'UTF-8',
 'headers': {'Content-Length': '13', 'Expires': 'Fri, 20 Sep 2019 10:18:26 GMT', 'Server': 'pve-api-daemon/3.0', 'Connection': 'close', 'Pragma': 'no-cache', 'Cache-Control': 'max-age=0', 'Date': 'Fri, 20 Sep 2019 10:18:26 GMT', 'Content-Type': 'application/json;charset=UTF-8'},
 'history': [],
 'raw': <requests.packages.urllib3.response.HTTPResponse object at 0x7fe214b635d0>,
 'reason': 'SSH public key validation error',
 'request': <PreparedRequest [POST]>,
 'status_code': 500,
 'url': u'https://proxmox-node:8006/api2/json/nodes/proxmox-node/lxc'}
```

The **_content** field added to message by PR https://github.com/swayf/proxmoxer/pull/34 does not contain the necessary data to analyze the problem
